### PR TITLE
shrinkscreenBlock call back fix

### DIFF
--- a/polyvSDK/Classes/SkinPlayer/SkinVideoViewController.m
+++ b/polyvSDK/Classes/SkinPlayer/SkinVideoViewController.m
@@ -1144,10 +1144,11 @@ typedef NS_ENUM(NSInteger, panHandler){
 		if (self.danmuEnabled) {
 			self.videoControl.sendDanmuButton.hidden = YES;
 		}
-		if (self.shrinkscreenBlock) {
+		
+	}
+	if (self.shrinkscreenBlock) {
 			self.shrinkscreenBlock();
 		}
-	}
 }
 
 


### PR DESCRIPTION
make `shrinkscreenBlock` available for all kinds of videoControl mode, including window mode.